### PR TITLE
New Header "x-rh-insights-request-id" needed

### DIFF
--- a/lib/topological_inventory/sync/sources_sync_worker.rb
+++ b/lib/topological_inventory/sync/sources_sync_worker.rb
@@ -91,7 +91,8 @@ module TopologicalInventory
         {
           "x-rh-identity" => Base64.strict_encode64(
             JSON.dump({"identity" => {"account_number" => tenant}})
-          )
+          ),
+          "x-rh-insights-request-id" => "1"
         }
       end
     end


### PR DESCRIPTION
sources-api throws KeyError and returns 401 unauthorized without header "x-rh-insights-request-id"